### PR TITLE
feat: tela de biblioteca + import de EPUB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,6 @@ Veja `docs/epub-reader-plan.md` seção 5 para detalhes.
 - [x] Estrutura de pastas criada
 - [x] App rodando no celular (Hello World)
 - [ ] Próxima feature: tela de biblioteca + import de EPUB
+
+## aprendizado de claude code
+ - aproveite para ir inserindo o usuario conhecimentos de claude code em nivel intermediario e avançado

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@capacitor/preferences": "^8.0.1",
         "dexie": "^4.4.2",
         "dexie-react-hooks": "^4.4.0",
+        "fflate": "^0.8.2",
         "foliate-js": "^1.0.1",
         "lucide-react": "^1.8.0",
         "react": "^19.2.4",
@@ -2475,6 +2476,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@capacitor/preferences": "^8.0.1",
     "dexie": "^4.4.2",
     "dexie-react-hooks": "^4.4.0",
+    "fflate": "^0.8.2",
     "foliate-js": "^1.0.1",
     "lucide-react": "^1.8.0",
     "react": "^19.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,35 @@
+import { useState } from 'react'
+import { LibraryScreen } from './screens/LibraryScreen'
+import type { Book } from './types/book'
+
+// Navegação simples por estado — sem react-router por enquanto.
+// Quando o Reader for implementado, migraremos pra react-router-dom.
+type Screen = 'library' | 'reader'
+
 function App() {
+  const [screen, setScreen] = useState<Screen>('library')
+  const [selectedBook, setSelectedBook] = useState<Book | null>(null)
+
+  function handleOpenBook(book: Book) {
+    setSelectedBook(book)
+    setScreen('reader')
+  }
+
+  if (screen === 'library') {
+    return <LibraryScreen onOpenBook={handleOpenBook} />
+  }
+
+  // Placeholder para o Reader (próxima feature)
   return (
-    <div className="min-h-screen bg-neutral-950 text-white p-6">
-      <h1 className="text-4xl font-bold text-indigo-500">NeoReader</h1>
-      <p className="text-neutral-400 mt-2">Read more. Learn faster.</p>
+    <div className="min-h-screen bg-[#0a0a0a] text-white flex flex-col items-center justify-center gap-4">
+      <p className="text-[#a0a0a0]">Leitor em breve...</p>
+      <p className="text-white font-semibold">{selectedBook?.title}</p>
+      <button
+        onClick={() => setScreen('library')}
+        className="text-[#6366f1] text-sm underline"
+      >
+        Voltar à biblioteca
+      </button>
     </div>
   )
 }

--- a/src/components/AddBookButton.tsx
+++ b/src/components/AddBookButton.tsx
@@ -1,0 +1,72 @@
+import { useRef, useState } from 'react'
+import { Plus } from 'lucide-react'
+import { EpubService } from '../services/EpubService'
+import { addBook } from '../db/books'
+
+export function AddBookButton() {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [importing, setImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setImporting(true)
+    setError(null)
+
+    try {
+      const metadata = await EpubService.parseMetadata(file)
+      await addBook({
+        title: metadata.title,
+        author: metadata.author,
+        coverBlob: metadata.coverBlob,
+        fileBlob: file,  // salva o arquivo completo para abrir no leitor depois
+        addedAt: new Date(),
+        lastOpenedAt: null,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro ao importar o arquivo'
+      setError(message)
+    } finally {
+      setImporting(false)
+      // Reseta o input para permitir selecionar o mesmo arquivo novamente
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  return (
+    <>
+      {/* Input oculto — o clique é disparado programaticamente pelo botão */}
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".epub"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      {/* FAB — Floating Action Button no canto inferior direito */}
+      <button
+        onClick={() => inputRef.current?.click()}
+        disabled={importing}
+        className="fixed bottom-6 right-6 w-14 h-14 rounded-full bg-[#6366f1] flex items-center justify-center shadow-lg active:scale-95 transition-transform duration-150 disabled:opacity-60"
+        aria-label="Adicionar livro"
+      >
+        {importing ? (
+          // Spinner simples enquanto importa
+          <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
+        ) : (
+          <Plus className="text-white" size={28} />
+        )}
+      </button>
+
+      {/* Toast de erro — aparece na base da tela */}
+      {error && (
+        <div className="fixed bottom-24 left-4 right-4 bg-red-900/90 text-white text-sm px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { db } from '../db/database'
+import type { Book } from '../types/book'
+
+interface BookCardProps {
+  book: Book
+  onPress: (book: Book) => void
+}
+
+export function BookCard({ book, onPress }: BookCardProps) {
+  // Busca o progresso deste livro do IndexedDB
+  const progress = useLiveQuery(
+    () => db.progress.where('bookId').equals(book.id!).first(),
+    [book.id],
+  )
+
+  // Converte o Blob da capa em uma URL de objeto para exibir no <img>
+  // useMemo evita recriar a URL a cada render
+  const coverUrl = useMemo(() => {
+    if (!book.coverBlob) return null
+    return URL.createObjectURL(book.coverBlob)
+    // Nota: em produção, revogaríamos essa URL com useEffect cleanup.
+    // Para o MVP isso é aceitável — o número de livros é pequeno.
+  }, [book.coverBlob])
+
+  const percentage = progress?.percentage ?? 0
+
+  return (
+    <button
+      onClick={() => onPress(book)}
+      className="flex flex-col gap-2 text-left active:scale-95 transition-transform duration-150"
+    >
+      {/* Capa do livro */}
+      <div className="relative w-full aspect-[2/3] rounded-md overflow-hidden bg-[#1a1a1a]">
+        {coverUrl ? (
+          <img
+            src={coverUrl}
+            alt={book.title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          // Placeholder quando não há capa
+          <div className="w-full h-full flex items-center justify-center">
+            <span className="text-4xl">📖</span>
+          </div>
+        )}
+
+        {/* Barra de progresso na base da capa — só aparece se tiver progresso */}
+        {percentage > 0 && (
+          <div className="absolute bottom-0 left-0 right-0 h-1 bg-black/40">
+            <div
+              className="h-full bg-[#22c55e] transition-all duration-300"
+              style={{ width: `${percentage}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Metadados */}
+      <div className="min-w-0">
+        <p className="text-white text-sm font-semibold truncate">{book.title}</p>
+        <p className="text-[#a0a0a0] text-xs truncate">{book.author}</p>
+      </div>
+    </button>
+  )
+}

--- a/src/db/books.ts
+++ b/src/db/books.ts
@@ -1,0 +1,23 @@
+import { db } from './database'
+import type { Book } from '../types/book'
+
+// Salva um livro novo no IndexedDB. Retorna o id gerado.
+export async function addBook(book: Omit<Book, 'id'>): Promise<number> {
+  return db.books.add(book)
+}
+
+// Retorna todos os livros, do mais recente ao mais antigo
+export async function getAllBooks(): Promise<Book[]> {
+  return db.books.orderBy('addedAt').reverse().toArray()
+}
+
+export async function deleteBook(id: number): Promise<void> {
+  await db.transaction('rw', db.books, db.progress, async () => {
+    await db.books.delete(id)
+    await db.progress.where('bookId').equals(id).delete()
+  })
+}
+
+export async function updateLastOpened(id: number): Promise<void> {
+  await db.books.update(id, { lastOpenedAt: new Date() })
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,0 +1,24 @@
+import Dexie, { type Table } from 'dexie'
+import type { Book, ReadingProgress } from '../types/book'
+
+// Dexie é um wrapper do IndexedDB — pensa nele como SQLite no browser.
+// Cada `Table<T>` é como uma tabela com schema declarado.
+class NeoReaderDB extends Dexie {
+  books!: Table<Book>
+  progress!: Table<ReadingProgress>
+
+  constructor() {
+    super('NeoReaderDB')
+
+    // version() define o schema — similar a uma migration.
+    // Os campos listados são os índices (busca rápida).
+    // Campos sem índice ainda existem, só não são buscáveis por eles.
+    this.version(1).stores({
+      books: '++id, title, author, addedAt, lastOpenedAt',
+      progress: '++id, bookId, updatedAt',
+    })
+  }
+}
+
+// Singleton — uma instância só pra todo o app
+export const db = new NeoReaderDB()

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -1,0 +1,18 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { db } from '../db/database'
+import type { Book } from '../types/book'
+
+// useLiveQuery é como um SELECT reativo: re-renderiza automaticamente
+// quando os dados no IndexedDB mudam. Equivale a um Observable/stream.
+export function useLibrary(): { books: Book[] | undefined; isEmpty: boolean } {
+  const books = useLiveQuery(
+    () => db.books.orderBy('addedAt').reverse().toArray(),
+    [], // dependências — array vazio = roda uma vez e fica observando
+  )
+
+  return {
+    books,
+    // undefined = ainda carregando; [] = carregado e vazio
+    isEmpty: books !== undefined && books.length === 0,
+  }
+}

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -1,0 +1,70 @@
+import { BookCard } from '../components/BookCard'
+import { AddBookButton } from '../components/AddBookButton'
+import { useLibrary } from '../hooks/useLibrary'
+import type { Book } from '../types/book'
+
+interface LibraryScreenProps {
+  onOpenBook: (book: Book) => void
+}
+
+export function LibraryScreen({ onOpenBook }: LibraryScreenProps) {
+  const { books, isEmpty } = useLibrary()
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] text-white">
+      {/* Header */}
+      <header className="px-4 pt-10 pb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-[#6366f1]">NeoReader</h1>
+        <p className="text-[#a0a0a0] text-sm">
+          {books ? `${books.length} livro${books.length !== 1 ? 's' : ''}` : ''}
+        </p>
+      </header>
+
+      <main className="px-4 pb-24">
+        {/* Estado: carregando (books = undefined enquanto Dexie inicializa) */}
+        {books === undefined && <SkeletonGrid />}
+
+        {/* Estado: biblioteca vazia */}
+        {isEmpty && <EmptyState />}
+
+        {/* Estado: com livros */}
+        {books && books.length > 0 && (
+          <div className="grid grid-cols-2 gap-4">
+            {books.map((book) => (
+              <BookCard key={book.id} book={book} onPress={onOpenBook} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <AddBookButton />
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 gap-4 text-center">
+      <span className="text-6xl">📚</span>
+      <h2 className="text-xl font-semibold text-white">Sua biblioteca está vazia</h2>
+      <p className="text-[#a0a0a0] text-sm max-w-56">
+        Toque no botão + para adicionar seu primeiro livro EPUB
+      </p>
+    </div>
+  )
+}
+
+// Skeleton com shimmer enquanto o IndexedDB inicializa (geralmente &lt;100ms)
+function SkeletonGrid() {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="flex flex-col gap-2">
+          <div className="w-full aspect-[2/3] rounded-md bg-[#1a1a1a] animate-pulse" />
+          <div className="h-3 w-3/4 rounded bg-[#1a1a1a] animate-pulse" />
+          <div className="h-2 w-1/2 rounded bg-[#1a1a1a] animate-pulse" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/services/EpubService.ts
+++ b/src/services/EpubService.ts
@@ -1,0 +1,111 @@
+import { unzip } from 'fflate'
+
+export interface EpubMetadata {
+  title: string
+  author: string
+  coverBlob: Blob | null
+}
+
+// EPUB é um ZIP. Esse serviço abre o ZIP e extrai os metadados do OPF.
+// Fluxo: container.xml → caminho do .opf → title/author/cover
+export class EpubService {
+  static async parseMetadata(file: File): Promise<EpubMetadata> {
+    const buffer = await file.arrayBuffer()
+    const uint8 = new Uint8Array(buffer)
+
+    // fflate.unzip é callback-based; wrapeamos em Promise
+    const files = await new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+      unzip(uint8, (err, data) => {
+        if (err) reject(err)
+        else resolve(data)
+      })
+    })
+
+    // 1. Ler container.xml para achar o path do OPF
+    const containerXml = this.readFileAsText(files, 'META-INF/container.xml')
+    if (!containerXml) throw new Error('EPUB inválido: META-INF/container.xml não encontrado')
+
+    const opfPath = this.extractOpfPath(containerXml)
+    if (!opfPath) throw new Error('EPUB inválido: path do OPF não encontrado')
+
+    // 2. Ler o OPF e extrair metadados
+    const opfXml = this.readFileAsText(files, opfPath)
+    if (!opfXml) throw new Error(`EPUB inválido: OPF não encontrado em ${opfPath}`)
+
+    const title = this.extractTag(opfXml, 'dc:title') ?? file.name.replace('.epub', '')
+    const author = this.extractTag(opfXml, 'dc:creator') ?? 'Autor desconhecido'
+
+    // 3. Extrair capa (opcional — muitos EPUBs não têm)
+    const coverBlob = this.extractCover(opfXml, opfPath, files)
+
+    return { title, author, coverBlob }
+  }
+
+  // Converte Uint8Array de um arquivo do ZIP para string UTF-8
+  private static readFileAsText(
+    files: Record<string, Uint8Array>,
+    path: string,
+  ): string | null {
+    // Alguns EPUBs usam caminhos com ou sem barra inicial
+    const data = files[path] ?? files[path.replace(/^\//, '')]
+    if (!data) return null
+    return new TextDecoder('utf-8').decode(data)
+  }
+
+  // Pega o caminho do OPF de dentro do container.xml
+  // Exemplo: <rootfile full-path="OEBPS/content.opf" .../>
+  private static extractOpfPath(containerXml: string): string | null {
+    const match = containerXml.match(/full-path="([^"]+\.opf)"/)
+    return match?.[1] ?? null
+  }
+
+  // Extrai o conteúdo de uma tag XML simples (sem atributos aninhados)
+  private static extractTag(xml: string, tag: string): string | null {
+    const match = xml.match(new RegExp(`<${tag}[^>]*>([^<]+)<\/${tag}>`))
+    return match?.[1]?.trim() ?? null
+  }
+
+  // Extrai a capa como Blob. EPUBs variam muito — estratégia: procura
+  // item com id "cover" ou properties="cover-image" no manifest.
+  private static extractCover(
+    opfXml: string,
+    opfPath: string,
+    files: Record<string, Uint8Array>,
+  ): Blob | null {
+    // Tenta encontrar href da capa no manifest
+    const coverHref =
+      this.extractCoverFromProperties(opfXml) ??
+      this.extractCoverFromMeta(opfXml)
+
+    if (!coverHref) return null
+
+    // O path do OPF dá o diretório base para resolver caminhos relativos
+    const opfDir = opfPath.includes('/') ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : ''
+    const coverPath = opfDir + coverHref
+
+    const coverData = files[coverPath] ?? files[coverPath.replace(/^\//, '')]
+    if (!coverData) return null
+
+    const mimeType = coverHref.endsWith('.png') ? 'image/png' : 'image/jpeg'
+    // .slice(0) retorna Uint8Array<ArrayBuffer> em vez de Uint8Array<ArrayBufferLike> — necessário pro TS strict
+    return new Blob([coverData.slice(0)], { type: mimeType })
+  }
+
+  // Estratégia 1: <item properties="cover-image" href="..."/>
+  private static extractCoverFromProperties(opfXml: string): string | null {
+    const match = opfXml.match(/properties="cover-image"[^>]*href="([^"]+)"/)
+              ?? opfXml.match(/href="([^"]+)"[^>]*properties="cover-image"/)
+    return match?.[1] ?? null
+  }
+
+  // Estratégia 2: <meta name="cover" content="cover-id"/> + <item id="cover-id" href="..."/>
+  private static extractCoverFromMeta(opfXml: string): string | null {
+    const metaMatch = opfXml.match(/<meta\s+name="cover"\s+content="([^"]+)"/)
+    if (!metaMatch) return null
+
+    const coverId = metaMatch[1]
+    const itemMatch = opfXml.match(new RegExp(`id="${coverId}"[^>]*href="([^"]+)"`))
+                  ?? opfXml.match(new RegExp(`href="([^"]+)"[^>]*id="${coverId}"`))
+    return itemMatch?.[1] ?? null
+  }
+}

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -1,0 +1,19 @@
+// Representa um livro armazenado no IndexedDB
+export interface Book {
+  id?: number          // auto-increment pelo Dexie
+  title: string
+  author: string
+  coverBlob: Blob | null  // imagem da capa extraída do EPUB
+  fileBlob: Blob          // arquivo .epub completo
+  addedAt: Date
+  lastOpenedAt: Date | null
+}
+
+// Progresso de leitura — CFI é o "endereço" de um ponto no EPUB
+export interface ReadingProgress {
+  id?: number
+  bookId: number
+  cfi: string       // EPUB Canonical Fragment Identifier (ex: "epubcfi(/6/4!/4/2/2:0)")
+  percentage: number // 0-100
+  updatedAt: Date
+}


### PR DESCRIPTION
## Resumo

- Schema Dexie com tabelas `books` e `progress` (IndexedDB)
- `EpubService`: extrai título, autor e capa do EPUB via `fflate` (ZIP parsing)
- `useLibrary`: live query reativo — grid atualiza automaticamente ao importar
- `BookCard`: capa, metadados e barra de progresso
- `AddBookButton`: FAB com file input nativo, spinner e toast de erro
- `LibraryScreen`: grid 2 colunas, estado vazio e skeleton loader
- `App.tsx`: navegação por estado (`library` → `reader` placeholder)

## Como testar

- [x] `npm run dev` → abre `localhost:5173` → tela de biblioteca vazia aparece
- [x] Clicar no `+` → selecionar um `.epub` → livro aparece na grid com capa e metadados
- [x] EPUB sem capa → placeholder de emoji aparece
- [x] EPUB corrompido → toast de erro aparece na tela
- [x] `npm run build` → build passa sem erros de tipo

🤖 Generated with [Claude Code](https://claude.com/claude-code)