### PR TITLE
feat: leitor EPUB e marcadores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@capacitor-community/text-to-speech": "^8.0.0",
         "@capacitor/android": "^8.3.0",
+        "@capacitor/app": "^8.1.0",
         "@capacitor/cli": "^8.3.0",
         "@capacitor/core": "^8.3.0",
         "@capacitor/filesystem": "^8.1.2",
@@ -296,6 +297,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@capacitor-community/text-to-speech": "^8.0.0",
     "@capacitor/android": "^8.3.0",
+    "@capacitor/app": "^8.1.0",
     "@capacitor/cli": "^8.3.0",
     "@capacitor/core": "^8.3.0",
     "@capacitor/filesystem": "^8.1.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 import { LibraryScreen } from './screens/LibraryScreen'
+import { ReaderScreen } from './screens/ReaderScreen'
 import type { Book } from './types/book'
 
-// Navegação simples por estado — sem react-router por enquanto.
-// Quando o Reader for implementado, migraremos pra react-router-dom.
 type Screen = 'library' | 'reader'
 
 function App() {
@@ -15,23 +14,11 @@ function App() {
     setScreen('reader')
   }
 
-  if (screen === 'library') {
-    return <LibraryScreen onOpenBook={handleOpenBook} />
+  if (screen === 'reader' && selectedBook) {
+    return <ReaderScreen book={selectedBook} onBack={() => setScreen('library')} />
   }
 
-  // Placeholder para o Reader (próxima feature)
-  return (
-    <div className="min-h-screen bg-[#0a0a0a] text-white flex flex-col items-center justify-center gap-4">
-      <p className="text-[#a0a0a0]">Leitor em breve...</p>
-      <p className="text-white font-semibold">{selectedBook?.title}</p>
-      <button
-        onClick={() => setScreen('library')}
-        className="text-[#6366f1] text-sm underline"
-      >
-        Voltar à biblioteca
-      </button>
-    </div>
-  )
+  return <LibraryScreen onOpenBook={handleOpenBook} />
 }
 
 export default App

--- a/src/components/reader/BookmarkSheet.tsx
+++ b/src/components/reader/BookmarkSheet.tsx
@@ -1,0 +1,67 @@
+import { X } from 'lucide-react'
+import type { Bookmark } from '../../types/book'
+
+interface BookmarkSheetProps {
+  open: boolean
+  bookmarks: Bookmark[]
+  onSelect: (cfi: string) => void
+  onDelete: (id: number) => void
+  onClose: () => void
+}
+
+export function BookmarkSheet({ open, bookmarks, onSelect, onDelete, onClose }: BookmarkSheetProps) {
+  const translateY = open ? 'translate-y-0' : 'translate-y-full'
+
+  return (
+    <>
+      {open && (
+        <div className="fixed inset-0 bg-black/60 z-[29]" onClick={onClose} />
+      )}
+
+      <div
+        className={`absolute inset-x-0 bottom-0 z-30 max-h-[60vh] bg-[#1a1a1a] rounded-t-2xl
+          transition-transform duration-300 ${translateY} flex flex-col`}
+      >
+        {/* Handle visual */}
+        <div className="flex justify-center pt-3 pb-2 shrink-0">
+          <div className="w-10 h-1 rounded-full bg-[#2a2a2a]" />
+        </div>
+
+        <h2 className="text-white font-semibold px-5 pb-3 shrink-0">Marcadores</h2>
+
+        <div className="overflow-y-auto flex-1 pb-8">
+          {bookmarks.length === 0 ? (
+            <p className="text-[#a0a0a0] text-sm px-5 py-4 leading-relaxed">
+              Nenhum marcador ainda.{'\n'}Toque em 🔖 durante a leitura para adicionar.
+            </p>
+          ) : (
+            bookmarks.map((bookmark) => (
+              <div
+                key={bookmark.id}
+                className="flex items-center gap-3 px-5 py-3 active:bg-[#2a2a2a]"
+              >
+                {/* Área clicável para navegar */}
+                <button
+                  className="flex-1 text-left min-w-0"
+                  onClick={() => onSelect(bookmark.cfi)}
+                >
+                  <p className="text-white text-sm truncate">{bookmark.label}</p>
+                  <p className="text-[#a0a0a0] text-xs mt-0.5">{bookmark.percentage}%</p>
+                </button>
+
+                {/* Botão de remoção */}
+                <button
+                  onClick={() => bookmark.id !== undefined && onDelete(bookmark.id)}
+                  className="p-2 text-[#a0a0a0] active:text-red-400 shrink-0"
+                  aria-label="Remover marcador"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/reader/EpubViewer.tsx
+++ b/src/components/reader/EpubViewer.tsx
@@ -1,0 +1,138 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+import type { Book } from '../../types/book'
+import type { View } from 'foliate-js/view.js'
+
+export type FontSize = 'sm' | 'md' | 'lg' | 'xl'
+
+// CSS injetado dentro do iframe do foliate para tema escuro + tamanho de fonte.
+// Precisa usar !important porque o EPUB tem seus próprios estilos inline e no <link>.
+function buildReaderCSS(fontSize: FontSize): string {
+  const sizes: Record<FontSize, string> = {
+    sm: '16px',
+    md: '18px',
+    lg: '22px',
+    xl: '26px',
+  }
+  return `
+    html, body {
+      background-color: #0a0a0a !important;
+      color: #e8e8e8 !important;
+      font-family: Georgia, Charter, serif !important;
+    }
+    * {
+      font-size: ${sizes[fontSize]} !important;
+      line-height: 1.7 !important;
+      color: #e8e8e8 !important;
+      background-color: transparent !important;
+    }
+    a { color: #818cf8 !important; }
+    h1, h2, h3, h4, h5, h6 {
+      color: #ffffff !important;
+    }
+  `
+}
+
+export interface EpubViewerHandle {
+  next(): void
+  prev(): void
+  goTo(target: string | number | { fraction: number }): void
+}
+
+interface EpubViewerProps {
+  book: Book
+  fontSize: FontSize
+  savedCfi: string | null
+  onRelocate: (cfi: string, percentage: number, tocLabel: string | undefined) => void
+  onTocReady: (toc: TocItem[]) => void
+  onLoad: () => void
+  onError: (err: Error) => void
+}
+
+// forwardRef: padrão React para expor métodos imperativos ao componente pai.
+// Equivale a um "ref de objeto" que o pai chama com viewerRef.current.next().
+export const EpubViewer = forwardRef<EpubViewerHandle, EpubViewerProps>(
+  ({ book, fontSize, savedCfi, onRelocate, onTocReady, onLoad, onError }, ref) => {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const viewRef = useRef<View | null>(null)
+
+    // Expõe API imperativa para o ReaderScreen via ref
+    useImperativeHandle(ref, () => ({
+      next: () => { viewRef.current?.next() },
+      prev: () => { viewRef.current?.prev() },
+      goTo: (target) => { viewRef.current?.goTo(target) },
+    }))
+
+    // Atualiza fonte sem recriar o view (efeito separado intencional)
+    useEffect(() => {
+      viewRef.current?.renderer.setStyles?.(buildReaderCSS(fontSize))
+    }, [fontSize])
+
+    // Setup principal: cria o elemento foliate, abre o EPUB, configura renderer.
+    // Roda apenas quando o bookId muda (novo livro), não a cada re-render.
+    useEffect(() => {
+      const container = containerRef.current
+      if (!container) return
+
+      let cancelled = false
+      let view: View | null = null
+
+      async function setup() {
+        // Import dinâmico: registra o custom element como side-effect
+        // e mantém o bundle do foliate fora do chunk inicial
+        await import('foliate-js/view.js')
+        if (cancelled) return
+
+        view = document.createElement('foliate-view') as unknown as View
+        view.style.cssText = 'width:100%;height:100%;display:block'
+        // container não pode ser null aqui: verificamos no início do useEffect
+        // e o elemento DOM não some enquanto o componente está montado
+        container!.appendChild(view)
+        viewRef.current = view
+
+        view.addEventListener('relocate', (e: CustomEvent<RelocateDetail>) => {
+          const { cfi, fraction, tocItem } = e.detail
+          onRelocate(cfi, Math.round(fraction * 100), tocItem?.label)
+        })
+
+        try {
+          await view.open(book.fileBlob)
+          if (cancelled) return
+
+          // Configura o renderer (elemento filho do foliate-view)
+          view.renderer.setAttribute('flow', 'paginated')
+          view.renderer.setAttribute('gap', '5%')
+          view.renderer.setAttribute('margin', '48px')
+          view.renderer.setAttribute('animated', '')
+          view.renderer.setStyles?.(buildReaderCSS(fontSize))
+
+          onTocReady(view.book?.toc ?? [])
+
+          // Restaura posição ou vai para o início do texto principal
+          await view.init(
+            savedCfi
+              ? { lastLocation: savedCfi }
+              : { showTextStart: true },
+          )
+
+          if (!cancelled) onLoad()
+        } catch (err) {
+          if (!cancelled) onError(err instanceof Error ? err : new Error(String(err)))
+        }
+      }
+
+      void setup()
+
+      return () => {
+        cancelled = true
+        view?.close()
+        view?.remove()
+        viewRef.current = null
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [book.id]) // Apenas quando muda o livro. Callbacks são estáveis no ReaderScreen.
+
+    return <div ref={containerRef} className="w-full h-full" />
+  },
+)
+
+EpubViewer.displayName = 'EpubViewer'

--- a/src/components/reader/ReaderChrome.tsx
+++ b/src/components/reader/ReaderChrome.tsx
@@ -1,0 +1,128 @@
+import { Bookmark, BookmarkCheck, ChevronLeft, List } from 'lucide-react'
+import type { FontSize } from './EpubViewer'
+
+interface ReaderChromeProps {
+  visible: boolean
+  title: string
+  percentage: number
+  fontSize: FontSize
+  isBookmarked: boolean
+  onBack: () => void
+  onFontSizeChange: (size: FontSize) => void
+  onBookmark: () => void
+  onTocOpen: () => void
+}
+
+const FONT_SIZES: { value: FontSize; label: string }[] = [
+  { value: 'sm', label: 'A' },
+  { value: 'md', label: 'A' },
+  { value: 'lg', label: 'A' },
+  { value: 'xl', label: 'A' },
+]
+
+// Tamanhos visuais dos botões de fonte (representação proporcional)
+const FONT_BUTTON_SIZES: Record<FontSize, string> = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-base',
+  xl: 'text-lg',
+}
+
+export function ReaderChrome({
+  visible,
+  title,
+  percentage,
+  fontSize,
+  isBookmarked,
+  onBack,
+  onFontSizeChange,
+  onBookmark,
+  onTocOpen,
+}: ReaderChromeProps) {
+  const translateTop = visible ? 'translate-y-0' : '-translate-y-full'
+  const translateBottom = visible ? 'translate-y-0' : 'translate-y-full'
+
+  return (
+    <>
+      {/* Top bar */}
+      <div
+        className={`absolute top-0 left-0 right-0 z-20 bg-[#0a0a0a]/90 backdrop-blur-sm
+          transition-transform duration-300 ${translateTop}`}
+      >
+        <div className="flex items-center justify-between px-4 pt-10 pb-3 gap-3">
+          <button
+            onClick={onBack}
+            className="p-2 -ml-2 text-white active:opacity-60"
+            aria-label="Voltar"
+          >
+            <ChevronLeft size={24} />
+          </button>
+
+          <p className="flex-1 text-white text-sm font-semibold truncate text-center">
+            {title}
+          </p>
+
+          {/* Bookmark: ícone preenchido (accent) se marcado, outline se não */}
+          <button
+            onClick={onBookmark}
+            className="p-2 active:opacity-60"
+            aria-label={isBookmarked ? 'Remover marcador' : 'Adicionar marcador'}
+          >
+            {isBookmarked
+              ? <BookmarkCheck size={22} className="text-[#6366f1]" />
+              : <Bookmark size={22} className="text-white" />
+            }
+          </button>
+
+          <button
+            onClick={onTocOpen}
+            className="p-2 -mr-2 text-white active:opacity-60"
+            aria-label="Marcadores"
+          >
+            <List size={24} />
+          </button>
+        </div>
+      </div>
+
+      {/* Bottom bar */}
+      <div
+        className={`absolute bottom-0 left-0 right-0 z-20 bg-[#0a0a0a]/90 backdrop-blur-sm
+          transition-transform duration-300 ${translateBottom}`}
+      >
+        {/* Barra de progresso fina */}
+        <div className="h-1 bg-[#1a1a1a]">
+          <div
+            className="h-full bg-[#22c55e] transition-all duration-500"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between px-6 py-4 pb-8">
+          {/* Botões de tamanho de fonte */}
+          <div className="flex items-center gap-3">
+            {FONT_SIZES.map((item) => (
+              <button
+                key={item.value}
+                onClick={() => onFontSizeChange(item.value)}
+                className={`w-9 h-9 rounded-md flex items-center justify-center font-serif
+                  ${FONT_BUTTON_SIZES[item.value]}
+                  ${fontSize === item.value
+                    ? 'bg-[#6366f1] text-white'
+                    : 'bg-[#1a1a1a] text-[#a0a0a0] active:opacity-60'
+                  }`}
+                aria-label={`Fonte ${item.value}`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Percentual de progresso */}
+          <span className="text-[#a0a0a0] text-sm tabular-nums">
+            {percentage}%
+          </span>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/reader/ReaderChrome.tsx
+++ b/src/components/reader/ReaderChrome.tsx
@@ -7,9 +7,11 @@ interface ReaderChromeProps {
   percentage: number
   fontSize: FontSize
   isBookmarked: boolean
+  bookmarkCount: number
   onBack: () => void
   onFontSizeChange: (size: FontSize) => void
   onBookmark: () => void
+  onBookmarkList: () => void
   onTocOpen: () => void
 }
 
@@ -34,9 +36,11 @@ export function ReaderChrome({
   percentage,
   fontSize,
   isBookmarked,
+  bookmarkCount,
   onBack,
   onFontSizeChange,
   onBookmark,
+  onBookmarkList,
   onTocOpen,
 }: ReaderChromeProps) {
   const translateTop = visible ? 'translate-y-0' : '-translate-y-full'
@@ -116,6 +120,18 @@ export function ReaderChrome({
               </button>
             ))}
           </div>
+
+          {/* Botão dedicado para abrir a lista de marcadores — separado do toggle 🔖 no top bar */}
+          <button
+            onClick={onBookmarkList}
+            className="flex items-center gap-1.5 text-[#a0a0a0] active:opacity-60"
+            aria-label="Ver marcadores"
+          >
+            <Bookmark size={18} />
+            {bookmarkCount > 0 && (
+              <span className="text-xs tabular-nums">{bookmarkCount}</span>
+            )}
+          </button>
 
           {/* Percentual de progresso */}
           <span className="text-[#a0a0a0] text-sm tabular-nums">

--- a/src/components/reader/TocSheet.tsx
+++ b/src/components/reader/TocSheet.tsx
@@ -1,0 +1,76 @@
+interface TocSheetProps {
+  open: boolean
+  toc: TocItem[]
+  onSelect: (href: string) => void
+  onClose: () => void
+}
+
+export function TocSheet({ open, toc, onSelect, onClose }: TocSheetProps) {
+  const translateY = open ? 'translate-y-0' : 'translate-y-full'
+
+  return (
+    <>
+      {/* Backdrop escuro — clique fecha o sheet */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/60 z-[29]"
+          onClick={onClose}
+        />
+      )}
+
+      {/* Sheet */}
+      <div
+        className={`absolute inset-x-0 bottom-0 z-30 max-h-[60vh] bg-[#1a1a1a] rounded-t-2xl
+          transition-transform duration-300 ${translateY} flex flex-col`}
+      >
+        {/* Handle visual */}
+        <div className="flex justify-center pt-3 pb-2 shrink-0">
+          <div className="w-10 h-1 rounded-full bg-[#2a2a2a]" />
+        </div>
+
+        <h2 className="text-white font-semibold px-5 pb-3 shrink-0">Índice</h2>
+
+        {/* Lista scrollável */}
+        <div className="overflow-y-auto flex-1 pb-8">
+          {toc.length === 0 ? (
+            <p className="text-[#a0a0a0] text-sm px-5 py-4">Índice não disponível</p>
+          ) : (
+            <TocList items={toc} depth={0} onSelect={onSelect} />
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+// Componente recursivo para subitens do TOC (ex: seções dentro de capítulos)
+function TocList({
+  items,
+  depth,
+  onSelect,
+}: {
+  items: TocItem[]
+  depth: number
+  onSelect: (href: string) => void
+}) {
+  return (
+    <>
+      {items.map((item, i) => (
+        <div key={`${item.href}-${i}`}>
+          <button
+            onClick={() => onSelect(item.href)}
+            // pl-5 base + pl-4 por nível de profundidade
+            className={`w-full text-left py-3 pr-5 text-sm active:bg-[#2a2a2a]
+              ${depth === 0 ? 'text-white' : 'text-[#a0a0a0]'}`}
+            style={{ paddingLeft: `${20 + depth * 16}px` }}
+          >
+            {item.label}
+          </button>
+          {item.subitems && item.subitems.length > 0 && (
+            <TocList items={item.subitems} depth={depth + 1} onSelect={onSelect} />
+          )}
+        </div>
+      ))}
+    </>
+  )
+}

--- a/src/db/bookmarks.ts
+++ b/src/db/bookmarks.ts
@@ -1,0 +1,14 @@
+import { db } from './database'
+
+export async function addBookmark(
+  bookId: number,
+  cfi: string,
+  label: string,
+  percentage: number,
+): Promise<number> {
+  return db.bookmarks.add({ bookId, cfi, label, percentage, createdAt: new Date() })
+}
+
+export async function deleteBookmark(id: number): Promise<void> {
+  return db.bookmarks.delete(id)
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,21 +1,29 @@
 import Dexie, { type Table } from 'dexie'
-import type { Book, ReadingProgress } from '../types/book'
+import type { Book, ReadingProgress, Bookmark } from '../types/book'
 
 // Dexie é um wrapper do IndexedDB — pensa nele como SQLite no browser.
 // Cada `Table<T>` é como uma tabela com schema declarado.
 class NeoReaderDB extends Dexie {
   books!: Table<Book>
   progress!: Table<ReadingProgress>
+  bookmarks!: Table<Bookmark>
 
   constructor() {
     super('NeoReaderDB')
 
     // version() define o schema — similar a uma migration.
     // Os campos listados são os índices (busca rápida).
-    // Campos sem índice ainda existem, só não são buscáveis por eles.
+    // Dexie migra automaticamente: dados da v1 são preservados.
     this.version(1).stores({
       books: '++id, title, author, addedAt, lastOpenedAt',
       progress: '++id, bookId, updatedAt',
+    })
+
+    // v2: adiciona tabela de marcadores
+    this.version(2).stores({
+      books: '++id, title, author, addedAt, lastOpenedAt',
+      progress: '++id, bookId, updatedAt',
+      bookmarks: '++id, bookId, createdAt',
     })
   }
 }

--- a/src/db/progress.ts
+++ b/src/db/progress.ts
@@ -1,0 +1,23 @@
+import { db } from './database'
+import type { ReadingProgress } from '../types/book'
+
+export async function getProgress(bookId: number): Promise<ReadingProgress | undefined> {
+  return db.progress.where('bookId').equals(bookId).first()
+}
+
+// IndexedDB não tem upsert nativo em chave não-primária.
+// Estratégia: busca pelo bookId, faz put se existe ou add se não existe.
+export async function upsertProgress(
+  bookId: number,
+  cfi: string,
+  percentage: number,
+): Promise<void> {
+  const existing = await db.progress.where('bookId').equals(bookId).first()
+  const record = { bookId, cfi, percentage, updatedAt: new Date() }
+
+  if (existing?.id !== undefined) {
+    await db.progress.put({ ...record, id: existing.id })
+  } else {
+    await db.progress.add(record)
+  }
+}

--- a/src/hooks/useReaderProgress.ts
+++ b/src/hooks/useReaderProgress.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getProgress, upsertProgress } from '../db/progress'
+
+interface UseReaderProgressResult {
+  savedCfi: string | null      // null = primeira abertura
+  initialLoadDone: boolean     // false enquanto o DB ainda não respondeu
+  saveProgress: (cfi: string, percentage: number) => void  // debounced
+}
+
+export function useReaderProgress(bookId: number): UseReaderProgressResult {
+  const [savedCfi, setSavedCfi] = useState<string | null>(null)
+  const [initialLoadDone, setInitialLoadDone] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Carrega posição salva uma vez no mount
+  useEffect(() => {
+    getProgress(bookId).then((p) => {
+      setSavedCfi(p?.cfi ?? null)
+      setInitialLoadDone(true)
+    })
+  }, [bookId])
+
+  // Salva com debounce de 1.5s para evitar writes excessivos a cada virada de página
+  const saveProgress = useCallback(
+    (cfi: string, percentage: number) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      debounceRef.current = setTimeout(() => {
+        upsertProgress(bookId, cfi, percentage)
+      }, 1500)
+    },
+    [bookId],
+  )
+
+  // Cancela qualquer debounce pendente ao desmontar
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  return { savedCfi, initialLoadDone, saveProgress }
+}

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -80,15 +80,14 @@ export function ReaderScreen({ book, onBack }: ReaderScreenProps) {
     onBack()
   }
 
-  // Tap no ícone 🔖:
-  // - Se não está marcado: adiciona marcador na posição atual
-  // - Se já está marcado: abre a lista de marcadores (para navegar ou remover)
+  // Toggle puro: adiciona se não existe, remove se já existe na posição atual.
+  // A lista de marcadores é acessada pelo botão dedicado no bottom bar.
   function handleBookmarkToggle() {
     if (!cfi || book.id === undefined) return
-    if (isBookmarked) {
-      setBookmarkSheetOpen(true)
+    const existing = bookmarks.find((b) => b.cfi === cfi)
+    if (existing?.id !== undefined) {
+      void deleteBookmark(existing.id)
     } else {
-      // Usa o nome do capítulo atual como label; fallback para "X%"
       void addBookmark(book.id, cfi, tocLabel || `${percentage}%`, percentage)
     }
   }
@@ -129,9 +128,11 @@ export function ReaderScreen({ book, onBack }: ReaderScreenProps) {
         percentage={percentage}
         fontSize={fontSize}
         isBookmarked={isBookmarked}
+        bookmarkCount={bookmarks.length}
         onBack={handleBack}
         onFontSizeChange={setFontSize}
         onBookmark={handleBookmarkToggle}
+        onBookmarkList={() => setBookmarkSheetOpen(true)}
         onTocOpen={() => setTocOpen(true)}
       />
 

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { App as CapApp } from '@capacitor/app'
+import { EpubViewer, type EpubViewerHandle, type FontSize } from '../components/reader/EpubViewer'
+import { ReaderChrome } from '../components/reader/ReaderChrome'
+import { TocSheet } from '../components/reader/TocSheet'
+import { BookmarkSheet } from '../components/reader/BookmarkSheet'
+import { useReaderProgress } from '../hooks/useReaderProgress'
+import { useReaderStore } from '../store/readerStore'
+import { upsertProgress } from '../db/progress'
+import { updateLastOpened } from '../db/books'
+import { addBookmark, deleteBookmark } from '../db/bookmarks'
+import { db } from '../db/database'
+import type { Book } from '../types/book'
+
+interface ReaderScreenProps {
+  book: Book
+  onBack: () => void
+}
+
+export function ReaderScreen({ book, onBack }: ReaderScreenProps) {
+  const viewerRef = useRef<EpubViewerHandle>(null)
+
+  // Estado local — não precisa ser compartilhado entre siblings
+  const [chromeVisible, setChromeVisible] = useState(false)
+  const [tocOpen, setTocOpen] = useState(false)
+  const [bookmarkSheetOpen, setBookmarkSheetOpen] = useState(false)
+  const [fontSize, setFontSize] = useState<FontSize>('md')
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Estado global compartilhado (Zustand)
+  const { cfi, percentage, tocLabel, toc, setCfi, setToc, reset } = useReaderStore()
+
+  // Progresso do IndexedDB (async)
+  const { savedCfi, initialLoadDone, saveProgress } = useReaderProgress(book.id!)
+
+  // Marcadores do livro atual — useLiveQuery: reativo, atualiza automaticamente
+  const bookmarks = useLiveQuery(
+    () => db.bookmarks.where('bookId').equals(book.id!).sortBy('createdAt'),
+    [book.id],
+  ) ?? []
+
+  // true se a posição atual já tem marcador salvo
+  const isBookmarked = bookmarks.some((b) => b.cfi === cfi)
+
+  // Limpa o store ao desmontar para não vazar estado entre livros
+  useEffect(() => { return () => reset() }, [reset])
+
+  // Atualiza lastOpenedAt quando o leitor abre
+  useEffect(() => {
+    if (book.id !== undefined) updateLastOpened(book.id)
+  }, [book.id])
+
+  // Intercepta o botão Back físico do Android (via plugin Capacitor)
+  useEffect(() => {
+    const listenerPromise = CapApp.addListener('backButton', () => {
+      if (bookmarkSheetOpen) { setBookmarkSheetOpen(false); return }
+      if (tocOpen) { setTocOpen(false); return }
+      handleBack()
+    })
+    return () => { void listenerPromise.then((l) => l.remove()) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tocOpen, bookmarkSheetOpen, cfi, percentage])
+
+  const handleRelocate = useCallback(
+    (newCfi: string, newPercentage: number, newTocLabel: string | undefined) => {
+      setCfi(newCfi, newPercentage, newTocLabel)
+      saveProgress(newCfi, newPercentage)
+    },
+    [setCfi, saveProgress],
+  )
+
+  // Flush imediato ao sair — garante que a posição não seja perdida
+  // se o usuário voltar antes do debounce de 1.5s disparar
+  function handleBack() {
+    if (cfi && book.id !== undefined) {
+      void upsertProgress(book.id, cfi, percentage)
+    }
+    onBack()
+  }
+
+  // Tap no ícone 🔖:
+  // - Se não está marcado: adiciona marcador na posição atual
+  // - Se já está marcado: abre a lista de marcadores (para navegar ou remover)
+  function handleBookmarkToggle() {
+    if (!cfi || book.id === undefined) return
+    if (isBookmarked) {
+      setBookmarkSheetOpen(true)
+    } else {
+      // Usa o nome do capítulo atual como label; fallback para "X%"
+      void addBookmark(book.id, cfi, tocLabel || `${percentage}%`, percentage)
+    }
+  }
+
+  // Zonas de toque: left 20% = prev, right 20% = next, centro = toggle chrome
+  function handleTapZone(e: React.PointerEvent<HTMLDivElement>) {
+    const x = e.clientX / window.innerWidth
+    if (x < 0.2) viewerRef.current?.prev()
+    else if (x > 0.8) viewerRef.current?.next()
+    else setChromeVisible((v) => !v)
+  }
+
+  // Aguarda o load do IndexedDB antes de montar o EpubViewer
+  if (!initialLoadDone) return <ReaderSkeleton />
+
+  return (
+    <div className="fixed inset-0 bg-[#0a0a0a]">
+      {isLoading && <ReaderSkeleton />}
+
+      <div className="absolute inset-0">
+        <EpubViewer
+          ref={viewerRef}
+          book={book}
+          fontSize={fontSize}
+          savedCfi={savedCfi}
+          onRelocate={handleRelocate}
+          onTocReady={setToc}
+          onLoad={() => setIsLoading(false)}
+          onError={(err) => { setIsLoading(false); setError(err.message) }}
+        />
+      </div>
+
+      <div className="absolute inset-0 z-10" onPointerUp={handleTapZone} />
+
+      <ReaderChrome
+        visible={chromeVisible}
+        title={book.title}
+        percentage={percentage}
+        fontSize={fontSize}
+        isBookmarked={isBookmarked}
+        onBack={handleBack}
+        onFontSizeChange={setFontSize}
+        onBookmark={handleBookmarkToggle}
+        onTocOpen={() => setTocOpen(true)}
+      />
+
+      <TocSheet
+        open={tocOpen}
+        toc={toc}
+        onSelect={(href) => {
+          viewerRef.current?.goTo(href)
+          setTocOpen(false)
+        }}
+        onClose={() => setTocOpen(false)}
+      />
+
+      <BookmarkSheet
+        open={bookmarkSheetOpen}
+        bookmarks={bookmarks}
+        onSelect={(bookmarkCfi) => {
+          viewerRef.current?.goTo(bookmarkCfi)
+          setBookmarkSheetOpen(false)
+        }}
+        onDelete={deleteBookmark}
+        onClose={() => setBookmarkSheetOpen(false)}
+      />
+
+      {error && (
+        <div className="absolute inset-0 z-40 bg-[#0a0a0a] flex flex-col items-center justify-center gap-4 px-8">
+          <p className="text-red-400 text-sm text-center">{error}</p>
+          <button onClick={handleBack} className="text-[#6366f1] text-sm underline">
+            Voltar à biblioteca
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReaderSkeleton() {
+  return (
+    <div className="fixed inset-0 bg-[#0a0a0a] flex items-center justify-center">
+      <div className="w-8 h-8 border-2 border-[#6366f1] border-t-transparent rounded-full animate-spin" />
+    </div>
+  )
+}

--- a/src/store/readerStore.ts
+++ b/src/store/readerStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand'
+
+// Estado compartilhado entre siblings do Reader:
+// EpubViewer (escreve) ↔ ReaderChrome (lê percentage) ↔ TocSheet (lê toc)
+// Estado puramente local (chromeVisible, fontSize, etc.) fica em useState no ReaderScreen.
+
+interface ReaderState {
+  cfi: string
+  percentage: number
+  toc: TocItem[]
+  tocLabel: string   // nome do capítulo atual (do evento relocate)
+  setCfi: (cfi: string, percentage: number, tocLabel: string | undefined) => void
+  setToc: (toc: TocItem[]) => void
+  reset: () => void // chamado no unmount do ReaderScreen para limpar estado residual
+}
+
+export const useReaderStore = create<ReaderState>((set) => ({
+  cfi: '',
+  percentage: 0,
+  toc: [],
+  tocLabel: '',
+  setCfi: (cfi, percentage, tocLabel) => set({ cfi, percentage, tocLabel: tocLabel ?? '' }),
+  setToc: (toc) => set({ toc }),
+  reset: () => set({ cfi: '', percentage: 0, toc: [], tocLabel: '' }),
+}))

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -17,3 +17,13 @@ export interface ReadingProgress {
   percentage: number // 0-100
   updatedAt: Date
 }
+
+// Marcador salvo pelo usuário em uma posição específica do livro
+export interface Bookmark {
+  id?: number
+  bookId: number
+  cfi: string
+  label: string      // nome do capítulo atual ou "X%" como fallback
+  percentage: number // para exibição na lista
+  createdAt: Date
+}

--- a/src/types/foliate.d.ts
+++ b/src/types/foliate.d.ts
@@ -1,0 +1,51 @@
+// Declarações TypeScript para foliate-js (pacote sem tipos nativos)
+
+interface TocItem {
+  label: string
+  href: string
+  subitems?: TocItem[]
+}
+
+interface RelocateDetail {
+  cfi: string
+  fraction: number // 0-1
+  tocItem?: { label: string; href: string }
+}
+
+declare module 'foliate-js/view.js' {
+  export class View extends HTMLElement {
+    book: {
+      toc: TocItem[]
+      metadata: Record<string, unknown>
+    }
+    renderer: HTMLElement & {
+      setAttribute(name: string, value: string): void
+      setStyles?(css: string): void
+    }
+    lastLocation: RelocateDetail | null
+
+    open(file: Blob | File): Promise<void>
+    init(opts: { lastLocation?: string; showTextStart?: boolean }): Promise<void>
+    next(distance?: number): Promise<void>
+    prev(distance?: number): Promise<void>
+    goTo(target: string | number | { fraction: number }): Promise<unknown>
+    close(): void
+
+    // Override para tipar os eventos customizados corretamente
+    addEventListener(
+      type: 'relocate',
+      listener: (e: CustomEvent<RelocateDetail>) => void,
+      options?: boolean | AddEventListenerOptions,
+    ): void
+    addEventListener(
+      type: 'load',
+      listener: (e: CustomEvent<{ doc: Document; index: number }>) => void,
+      options?: boolean | AddEventListenerOptions,
+    ): void
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ): void
+  }
+}


### PR DESCRIPTION
## Resumo

### Leitor (foliate-js)
- `EpubViewer`: wrapper do custom element `foliate-view` com `forwardRef` (next/prev/goTo)
- `ReaderChrome`: top bar (voltar, título, bookmark, TOC) + bottom bar (fonte, progresso, lista de marcadores)
- `TocSheet`: bottom sheet com índice navegável
- `ReaderScreen`: tap zones (left/center/right), back button Android, flush de progresso no back
- Progresso persistente no IndexedDB com debounce de 1.5s
- Tema escuro com CSS injetado no iframe do foliate

### Marcadores
- `BookmarkSheet`: lista de marcadores com navegação direta e remoção
- Dexie v2: migração com tabela `bookmarks` (dados da v1 preservados)
- Botão 🔖 no top bar: toggle puro (outline = adiciona, filled = remove)
- Botão dedicado no bottom bar: abre a lista sem criar marcador acidentalmente
- Exibe contagem de marcadores no botão da lista
- `useLiveQuery` reativo: ícone e lista atualizam sem refresh

## Como testar

- [ ] `npm run dev` → abrir livro → leitor abre em tela cheia
- [ ] Tap nas bordas (20%) navega páginas; tap no centro toggle chrome
- [ ] Botão 🔖 → ícone muda para preenchido (accent); tap novamente → remove
- [ ] Botão 🔖 no bottom bar → abre lista de marcadores sem criar novo
- [ ] Tap em marcador na lista → navega para posição
- [ ] X na lista → remove marcador, contagem atualiza
- [ ] Fechar e reabrir → livro abre no mesmo ponto, marcadores persistem
- [ ] `npm run build` → zero erros de tipo

🤖 Generated with [Claude Code](https://claude.com/claude-code)