### PR TITLE
fix: corrige perda de progresso e falsos negativos em marcadores

### DIFF
--- a/src/components/reader/EpubViewer.tsx
+++ b/src/components/reader/EpubViewer.tsx
@@ -841,15 +841,22 @@ export const EpubViewer = forwardRef<EpubViewerHandle, EpubViewerProps>(
           onTocReady(view.book?.toc ?? [])
 
           // CFI com [Cover] = capa sem conteúdo legível → tela preta no tema escuro.
-          // Tratamos como "sem posição salva" e começamos pelo primeiro texto real.
+          // Validamos o formato antes de usar: CFI inválido (livro reprocessado, seção removida)
+          // deve fazer fallback silencioso em vez de mostrar tela de erro.
           const isAtCover = !!savedCfi?.match(/\[Cover\]/i)
-          const initCfi = savedCfi && !isAtCover ? savedCfi : null
-          console.log('[nr-debug]', 'calling view.init()', { savedCfi, isAtCover, initCfi })
-          await view.init(
-            initCfi
-              ? { lastLocation: initCfi }
-              : { showTextStart: true },
-          )
+          const isValidCfi = savedCfi && !isAtCover && savedCfi.startsWith('epubcfi(')
+          const initCfi = isValidCfi ? savedCfi : null
+          console.log('[nr-debug]', 'calling view.init()', { savedCfi, isValidCfi, initCfi })
+          try {
+            await view.init(
+              initCfi
+                ? { lastLocation: initCfi }
+                : { showTextStart: true },
+            )
+          } catch {
+            // CFI inválido (seção removida, livro reprocessado) → recomeça do início sem erro
+            await view.init({ showTextStart: true })
+          }
           console.log('[nr-debug]', 'view.init() resolved')
 
           if (loadTimeout) clearTimeout(loadTimeout)

--- a/src/db/bookmarks.ts
+++ b/src/db/bookmarks.ts
@@ -1,4 +1,5 @@
 import { db } from './database'
+import { normalizeCfi } from '../utils/cfiUtils'
 
 export async function addBookmark(
   bookId: number,
@@ -6,7 +7,14 @@ export async function addBookmark(
   label: string,
   percentage: number,
 ): Promise<number> {
-  return db.bookmarks.add({ bookId, cfi, label, percentage, createdAt: new Date() })
+  // Transação garante que multi-tap rápido não cria duplicatas no mesmo ponto
+  return db.transaction('rw', db.bookmarks, async () => {
+    const norm = normalizeCfi(cfi)
+    const all = await db.bookmarks.where('bookId').equals(bookId).toArray()
+    const dup = all.find(b => normalizeCfi(b.cfi) === norm)
+    if (dup?.id !== undefined) return dup.id
+    return db.bookmarks.add({ bookId, cfi, label, percentage, createdAt: new Date() })
+  })
 }
 
 export async function deleteBookmark(id: number): Promise<void> {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -49,6 +49,31 @@ class NeoReaderDB extends Dexie {
       translations:'++id, textHash, createdAt',
       settings:    '++id',
     })
+
+    // v5: índice único em progress.bookId (elimina duplicatas) + índice cfi em bookmarks (busca eficiente)
+    // A migration deduplica registros de progress antes de aplicar o índice único (&bookId)
+    this.version(5)
+      .stores({
+        books:        '++id, title, author, addedAt, lastOpenedAt',
+        progress:     '++id, &bookId, updatedAt',
+        bookmarks:    '++id, bookId, cfi, createdAt',
+        vocabulary:   '++id, bookId, createdAt',
+        translations: '++id, textHash, createdAt',
+        settings:     '++id',
+      })
+      .upgrade(async tx => {
+        // Mantém apenas o registro mais recente por bookId antes de aplicar índice único
+        const all = await tx.table('progress').toArray()
+        const byBook = new Map<number, (typeof all)[0]>()
+        for (const row of all) {
+          const prev = byBook.get(row.bookId)
+          if (!prev || row.updatedAt > prev.updatedAt) byBook.set(row.bookId, row)
+        }
+        const toDelete = all
+          .filter(r => byBook.get(r.bookId)?.id !== r.id)
+          .map(r => r.id!)
+        if (toDelete.length > 0) await tx.table('progress').bulkDelete(toDelete)
+      })
   }
 }
 

--- a/src/db/progress.ts
+++ b/src/db/progress.ts
@@ -2,22 +2,27 @@ import { db } from './database'
 import type { ReadingProgress } from '../types/book'
 
 export async function getProgress(bookId: number): Promise<ReadingProgress | undefined> {
-  return db.progress.where('bookId').equals(bookId).first()
+  // Ordena por updatedAt e retorna o mais recente — garante resultado correto mesmo se houver
+  // registros duplicados de versões anteriores ao schema v5 (que adicionou índice único)
+  const all = await db.progress.where('bookId').equals(bookId).sortBy('updatedAt')
+  return all[all.length - 1]
 }
 
-// IndexedDB não tem upsert nativo em chave não-primária.
-// Estratégia: busca pelo bookId, faz put se existe ou add se não existe.
+// Envolve a operação em transação para evitar race condition entre debounce e flush simultâneos
+// (ambos resolvem o where().first() antes do put → segundo add cria duplicata)
 export async function upsertProgress(
   bookId: number,
   cfi: string,
   percentage: number,
 ): Promise<void> {
-  const existing = await db.progress.where('bookId').equals(bookId).first()
-  const record = { bookId, cfi, percentage, updatedAt: new Date() }
+  await db.transaction('rw', db.progress, async () => {
+    const existing = await db.progress.where('bookId').equals(bookId).first()
+    const record = { bookId, cfi, percentage, updatedAt: new Date() }
 
-  if (existing?.id !== undefined) {
-    await db.progress.put({ ...record, id: existing.id })
-  } else {
-    await db.progress.add(record)
-  }
+    if (existing?.id !== undefined) {
+      await db.progress.update(existing.id, { cfi, percentage, updatedAt: new Date() })
+    } else {
+      await db.progress.add(record)
+    }
+  })
 }

--- a/src/hooks/useReaderProgress.ts
+++ b/src/hooks/useReaderProgress.ts
@@ -1,18 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { App as CapApp } from '@capacitor/app'
 import { getProgress, upsertProgress } from '../db/progress'
 
 interface UseReaderProgressResult {
   savedCfi: string | null      // null = primeira abertura
   initialLoadDone: boolean     // false enquanto o DB ainda não respondeu
   saveProgress: (cfi: string, percentage: number) => void  // debounced
+  flush: () => void            // salva imediatamente se houver pending
 }
 
 export function useReaderProgress(bookId: number): UseReaderProgressResult {
   const [savedCfi, setSavedCfi] = useState<string | null>(null)
   const [initialLoadDone, setInitialLoadDone] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Mantém o último par cfi/percentage para flush seguro mesmo após o store resetar
+  const pendingRef = useRef<{ cfi: string; percentage: number } | null>(null)
 
-  // Carrega posição salva uma vez no mount
   useEffect(() => {
     getProgress(bookId).then((p) => {
       setSavedCfi(p?.cfi ?? null)
@@ -20,23 +23,40 @@ export function useReaderProgress(bookId: number): UseReaderProgressResult {
     })
   }, [bookId])
 
+  const flush = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (pendingRef.current) {
+      void upsertProgress(bookId, pendingRef.current.cfi, pendingRef.current.percentage)
+      pendingRef.current = null
+    }
+  }, [bookId])
+
   // Salva com debounce de 1.5s para evitar writes excessivos a cada virada de página
   const saveProgress = useCallback(
     (cfi: string, percentage: number) => {
+      pendingRef.current = { cfi, percentage }
       if (debounceRef.current) clearTimeout(debounceRef.current)
       debounceRef.current = setTimeout(() => {
-        upsertProgress(bookId, cfi, percentage)
+        if (pendingRef.current) {
+          void upsertProgress(bookId, pendingRef.current.cfi, pendingRef.current.percentage)
+          pendingRef.current = null
+        }
       }, 1500)
     },
     [bookId],
   )
 
-  // Cancela qualquer debounce pendente ao desmontar
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
-    }
-  }, [])
+  // Flush ao desmontar — cobre navegação via botão Voltar antes dos 1.5s
+  useEffect(() => () => flush(), [flush])
 
-  return { savedCfi, initialLoadDone, saveProgress }
+  // Flush ao ir para background — cobre Home button, swipe-to-close e morte do processo
+  useEffect(() => {
+    let remove: (() => void) | null = null
+    CapApp.addListener('appStateChange', ({ isActive }) => {
+      if (!isActive) flush()
+    }).then(l => { remove = () => l.remove() })
+    return () => remove?.()
+  }, [flush])
+
+  return { savedCfi, initialLoadDone, saveProgress, flush }
 }

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -7,12 +7,12 @@ import { TocDrawer } from '../components/reader/TocDrawer'
 import { BookmarkSheet } from '../components/reader/BookmarkSheet'
 import { useReaderProgress } from '../hooks/useReaderProgress'
 import { useReaderStore } from '../store/readerStore'
-import { upsertProgress } from '../db/progress'
 import { updateLastOpened } from '../db/books'
 import { addBookmark, deleteBookmark } from '../db/bookmarks'
 import { addVocabItem } from '../db/vocabulary'
 import { getSettings } from '../db/settings'
 import { db } from '../db/database'
+import { normalizeCfi } from '../utils/cfiUtils'
 import { useTTS } from '../hooks/useTTS'
 import { TtsMiniPlayer } from '../components/reader/TtsMiniPlayer'
 import { SpeechifyService } from '../services/SpeechifyService'
@@ -51,7 +51,7 @@ export function ReaderScreen({ book, onBack, onOpenVocabulary }: ReaderScreenPro
   const { cfi, percentage, tocLabel, toc, setCfi, setToc, reset } = useReaderStore()
 
   // Progresso do IndexedDB (async)
-  const { savedCfi, initialLoadDone, saveProgress } = useReaderProgress(book.id!)
+  const { savedCfi, initialLoadDone, saveProgress, flush: flushProgress } = useReaderProgress(book.id!)
 
   // Marcadores do livro atual — useLiveQuery: reativo, atualiza automaticamente
   const bookmarks = useLiveQuery(
@@ -59,8 +59,8 @@ export function ReaderScreen({ book, onBack, onOpenVocabulary }: ReaderScreenPro
     [book.id],
   ) ?? []
 
-  // true se a posição atual já tem marcador salvo
-  const isBookmarked = bookmarks.some((b) => b.cfi === cfi)
+  // Compara por nó (sem offset de caractere) — o mesmo ponto visual pode ter CFIs com :offset diferente
+  const isBookmarked = cfi ? bookmarks.some((b) => normalizeCfi(b.cfi) === normalizeCfi(cfi)) : false
 
   // Limpa o store ao desmontar para não vazar estado entre livros
   useEffect(() => { return () => reset() }, [reset])
@@ -226,17 +226,16 @@ export function ReaderScreen({ book, onBack, onOpenVocabulary }: ReaderScreenPro
   // Flush imediato ao sair — garante que a posição não seja perdida
   // se o usuário voltar antes do debounce de 1.5s disparar
   function handleBack() {
-    if (cfi && book.id !== undefined) {
-      void upsertProgress(book.id, cfi, percentage)
-    }
+    flushProgress()
     onBack()
   }
 
   // Toggle puro: adiciona se não existe, remove se já existe na posição atual.
-  // A lista de marcadores é acessada pelo botão dedicado no bottom bar.
+  // Usa normalizeCfi para comparar por nó (sem offset) — evita falso negativo.
   function handleBookmarkToggle() {
     if (!cfi || book.id === undefined) return
-    const existing = bookmarks.find((b) => b.cfi === cfi)
+    const norm = normalizeCfi(cfi)
+    const existing = bookmarks.find((b) => normalizeCfi(b.cfi) === norm)
     if (existing?.id !== undefined) {
       void deleteBookmark(existing.id)
     } else {

--- a/src/utils/cfiUtils.ts
+++ b/src/utils/cfiUtils.ts
@@ -1,0 +1,6 @@
+// Remove o offset de caractere do final de um CFI para comparação por posição de nó.
+// epubcfi(/6/4!/4/2/2:14) → epubcfi(/6/4!/4/2/2)
+// Evita falso negativo em isBookmarked: o mesmo nó pode ter offsets diferentes entre relocates.
+export function normalizeCfi(cfi: string): string {
+  return cfi.replace(/:[\d]+(\[.*?\])?$/, '')
+}


### PR DESCRIPTION
- Cria `cfiUtils.normalizeCfi` para comparar CFIs sem offset de caractere
- `useReaderProgress`: adiciona `pendingRef`, expõe `flush`, faz flush no unmount e no evento `appStateChange` (app vai para background)
- `db/progress`: envolve upsert em transação (elimina race condition), `getProgress` retorna registro mais recente por `updatedAt`
- `db/bookmarks`: `addBookmark` deduplica por CFI normalizado em transação
- `ReaderScreen`: usa `normalizeCfi` em `isBookmarked` e `handleBookmarkToggle`, `handleBack` chama `flush()` em vez de `upsertProgress` direto
- `EpubViewer`: fallback silencioso se CFI salvo for inválido (seção removida)
- `database`: schema v5 com `&bookId` único em `progress` + índice `cfi` em `bookmarks`, migration deduplicação antes de aplicar índice único

Closes #26