### PR TITLE
fix: remove scroll listeners do capítulo anterior no load para evitar…

### DIFF
--- a/src/components/reader/EpubViewer.tsx
+++ b/src/components/reader/EpubViewer.tsx
@@ -1148,6 +1148,11 @@ export const EpubViewer = forwardRef<EpubViewerHandle, EpubViewerProps>(
             index: e.detail.index,
             version: pendingSectionVersionRef.current,
           }
+          // Remove listeners do capítulo anterior imediatamente: sem esse cleanup eles
+          // ficam ativos ~400ms e disparam com o índice do novo capítulo já setado,
+          // causando o banner de "fim de capítulo" aparecer no início do próximo.
+          scrollListenerCleanupRef.current?.()
+          scrollListenerCleanupRef.current = null
           isAtBottomRef.current = false
           const hasNext = e.detail.index < totalSectionsRef.current - 1
           onAtBottomRef.current?.(false, hasNext, hasNext ? getNextSectionLabel(e.detail.index) : undefined)


### PR DESCRIPTION
… banner falso

Quando um novo capítulo carregava, o evento 'load' resetava isAtBottomRef=false mas os scroll listeners do capítulo anterior continuavam ativos por ~400ms (até finalizePendingSection rodar). Nesse intervalo, eles disparavam com currentSectionIdxRef já apontando para o novo capítulo — e como capítulos curtos cabem na viewport, atBottom=true era reportado, fazendo o banner 'Fim do capítulo' aparecer no início do novo capítulo.

Fixes #32