### PR TITLE
feat: exibe badge do modelo e ordena vozes ElevenLabs por versão

### DIFF
--- a/src/db/ttsVoiceCaches.ts
+++ b/src/db/ttsVoiceCaches.ts
@@ -10,8 +10,11 @@ function hashCacheKey(input: string): number {
   return hash
 }
 
+// Incrementar quando o schema de TtsVoiceOption mudar, para invalidar caches antigos
+const VOICE_CACHE_VERSION = 2
+
 export function buildTtsVoiceCacheKey(provider: TtsProvider, language: string, apiKey: string): number {
-  return hashCacheKey(`${provider}::${language}::${apiKey}`)
+  return hashCacheKey(`v${VOICE_CACHE_VERSION}::${provider}::${language}::${apiKey}`)
 }
 
 export async function getCachedTtsVoiceOptions(cacheKey: number, maxAgeMs: number): Promise<TtsVoiceOption[] | null> {


### PR DESCRIPTION
- Adiciona campo modelId em TtsVoiceOption, populado via verified_languages
- Vozes ordenadas por prioridade de modelo (v3 > v2.5 > v2 > outros), alfabético dentro do grupo
- Badge colorido na lista: verde para v3+, índigo para v2, cinza para outros

https://claude.ai/code/session_01KwQqyfwEuAvH9SmJSYf7AY