### PR TITLE
feat: exibe badge do modelo e ordena vozes ElevenLabs por versão

### DIFF
--- a/src/screens/BookDetailsScreen.tsx
+++ b/src/screens/BookDetailsScreen.tsx
@@ -1199,7 +1199,12 @@ export function BookDetailsScreen({ book, onBack, onRead, onOpenSettings }: Book
                       </div>
                     )}
                     title={voice.label}
-                    meta={[voice.locale, voice.meta].filter(Boolean).join(' - ')}
+                    meta={(
+                      <span className="flex items-center gap-1.5 flex-wrap">
+                        {voice.modelId && <VoiceModelBadge modelId={voice.modelId} />}
+                        <span>{[voice.locale, voice.meta].filter(Boolean).join(' · ')}</span>
+                      </span>
+                    )}
                     trailing={(
                       <div className="flex items-center gap-2">
                         <button
@@ -1767,6 +1772,33 @@ function formatTtsRate(rate: number): string {
 
 function formatTtsWordsPerMinute(rate: number): string {
   return `${Math.round(rate * 200)} wpm`
+}
+
+function getModelBadgeLabel(modelId: string): string {
+  const match = modelId.match(/_v(\d+)(?:_(\d+))?/)
+  if (!match) return modelId
+  const version = match[2] ? `v${match[1]}.${match[2]}` : `v${match[1]}`
+  if (modelId.includes('turbo')) return `turbo ${version}`
+  if (modelId.includes('flash')) return `flash ${version}`
+  return version
+}
+
+function VoiceModelBadge({ modelId }: { modelId: string }) {
+  const label = getModelBadgeLabel(modelId)
+  // v3+ fica verde, v2.x fica índigo, resto cinza
+  const match = modelId.match(/_v(\d+)(?:_(\d+))?/)
+  const version = match ? parseInt(match[1], 10) + (match[2] ? parseInt(match[2], 10) / 10 : 0) : 0
+  const colorClass = version >= 3
+    ? 'bg-emerald-500/20 text-emerald-400'
+    : version >= 2
+      ? 'bg-indigo-500/20 text-indigo-400'
+      : 'bg-white/10 text-text-muted'
+
+  return (
+    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide ${colorClass}`}>
+      {label}
+    </span>
+  )
 }
 
 function PrimeVideoBadge({

--- a/src/services/ElevenLabsService.ts
+++ b/src/services/ElevenLabsService.ts
@@ -329,6 +329,15 @@ function pickVerifiedLanguage(voice: ElevenLabsVoice, language: string) {
   ) ?? null
 }
 
+function getModelPriority(modelId: string): number {
+  // Extrai versão do model_id, ex: "eleven_multilingual_v3" → 3.0, "eleven_turbo_v2_5" → 2.5
+  const match = modelId.match(/_v(\d+)(?:_(\d+))?/)
+  if (!match) return 0
+  const major = parseInt(match[1], 10)
+  const minor = match[2] ? parseInt(match[2], 10) / 10 : 0
+  return major + minor
+}
+
 function toCompatibleVoiceOption(voice: ElevenLabsVoice, normalizedLanguage: string): TtsVoiceOption | null {
   const verifiedLanguage = pickVerifiedLanguage(voice, normalizedLanguage)
   if (!verifiedLanguage) return null
@@ -340,6 +349,7 @@ function toCompatibleVoiceOption(voice: ElevenLabsVoice, normalizedLanguage: str
     provider: 'elevenlabs' as const,
     previewUrl: verifiedLanguage.preview_url ?? voice.preview_url,
     meta: buildVoiceMeta(voice),
+    modelId: verifiedLanguage.model_id,
   }
 }
 
@@ -505,7 +515,10 @@ export const ElevenLabsService = {
         : null
     } while (nextPageToken)
 
-    const sortedVoices = compatibleVoices.sort((left, right) => left.label.localeCompare(right.label))
+    const sortedVoices = compatibleVoices.sort((left, right) => {
+      const priorityDiff = getModelPriority(right.modelId ?? '') - getModelPriority(left.modelId ?? '')
+      return priorityDiff !== 0 ? priorityDiff : left.label.localeCompare(right.label)
+    })
     await setCachedTtsVoiceOptions({
       cacheKey,
       provider: 'elevenlabs',

--- a/src/types/tts.ts
+++ b/src/types/tts.ts
@@ -8,6 +8,7 @@ export interface TtsVoiceOption {
   previewUrl?: string | null
   avatarUrl?: string | null
   meta?: string
+  modelId?: string
 }
 
 export interface TtsVoiceCacheRecord {


### PR DESCRIPTION
- Adiciona campo modelId em TtsVoiceOption, populado via verified_languages
- Vozes ordenadas por prioridade de modelo (v3 > v2.5 > v2 > outros), alfabético dentro do grupo
- Badge colorido na lista: verde para v3+, índigo para v2, cinza para outros

https://claude.ai/code/session_01KwQqyfwEuAvH9SmJSYf7AY