### PR TITLE
fix: usa high_quality_base_model_ids para detectar suporte a v3

### DIFF
--- a/src/db/ttsVoiceCaches.ts
+++ b/src/db/ttsVoiceCaches.ts
@@ -11,7 +11,7 @@ function hashCacheKey(input: string): number {
 }
 
 // Incrementar quando o schema de TtsVoiceOption mudar, para invalidar caches antigos
-const VOICE_CACHE_VERSION = 2
+const VOICE_CACHE_VERSION = 3
 
 export function buildTtsVoiceCacheKey(provider: TtsProvider, language: string, apiKey: string): number {
   return hashCacheKey(`v${VOICE_CACHE_VERSION}::${provider}::${language}::${apiKey}`)

--- a/src/services/ElevenLabsService.ts
+++ b/src/services/ElevenLabsService.ts
@@ -338,6 +338,16 @@ function getModelPriority(modelId: string): number {
   return major + minor
 }
 
+// verified_languages.model_id frequentemente indica v2 mesmo que a voz suporte v3.
+// high_quality_base_model_ids lista todos os modelos HQ disponíveis — usamos o melhor.
+function pickBestModelId(verifiedModelId: string, highQualityModelIds?: string[] | null): string {
+  if (!highQualityModelIds?.length) return verifiedModelId
+  const candidates = [verifiedModelId, ...highQualityModelIds]
+  return candidates.reduce((best, modelId) =>
+    getModelPriority(modelId) > getModelPriority(best) ? modelId : best,
+  )
+}
+
 function toCompatibleVoiceOption(voice: ElevenLabsVoice, normalizedLanguage: string): TtsVoiceOption | null {
   const verifiedLanguage = pickVerifiedLanguage(voice, normalizedLanguage)
   if (!verifiedLanguage) return null
@@ -349,7 +359,7 @@ function toCompatibleVoiceOption(voice: ElevenLabsVoice, normalizedLanguage: str
     provider: 'elevenlabs' as const,
     previewUrl: verifiedLanguage.preview_url ?? voice.preview_url,
     meta: buildVoiceMeta(voice),
-    modelId: verifiedLanguage.model_id,
+    modelId: pickBestModelId(verifiedLanguage.model_id, voice.high_quality_base_model_ids),
   }
 }
 
@@ -382,8 +392,9 @@ async function resolveVoiceId(apiKey: string, language: string, voiceId?: string
   return fallbackVoiceId
 }
 
-function getSelectedModelId(verifiedLanguage: ElevenLabsVoiceLanguage | null) {
-  return verifiedLanguage?.model_id ?? DEFAULT_MODEL_ID
+function getSelectedModelId(verifiedLanguage: ElevenLabsVoiceLanguage | null, highQualityModelIds?: string[] | null) {
+  const baseModelId = verifiedLanguage?.model_id ?? DEFAULT_MODEL_ID
+  return pickBestModelId(baseModelId, highQualityModelIds)
 }
 
 function buildSpeechRequestBody(
@@ -551,7 +562,7 @@ export const ElevenLabsService = {
       options.voiceId,
     )
     const verifiedLanguage = pickVerifiedLanguage(voice, normalizedLanguage)
-    const selectedModelId = getSelectedModelId(verifiedLanguage)
+    const selectedModelId = getSelectedModelId(verifiedLanguage, voice.high_quality_base_model_ids)
     const timestampsEndpoint = `${API_URL}/${resolvedVoiceId}/with-timestamps`
     const timestampsRequestBody = {
       ...buildSpeechRequestBody(


### PR DESCRIPTION
verified_languages.model_id frequentemente indica v2 mesmo para vozes que suportam v3. Agora pickBestModelId compara o modelo verificado com todos os high_quality_base_model_ids e usa o de maior versão — tanto no badge/sort da lista quanto na síntese real. Cache v3 para revalidar.

https://claude.ai/code/session_01KwQqyfwEuAvH9SmJSYf7AY